### PR TITLE
Fixed context when the user doesn't have a course

### DIFF
--- a/context.py
+++ b/context.py
@@ -136,7 +136,9 @@ def get_context(**kwargs):
         if not (viewer_is_student or viewer_is_instructor):
             forbidden(context)
     _set_course_context(context, url_args, **kwargs)
-    course = context['course']
+    course = None
+    if 'course' in context:
+        course = context['course']
     _set_instructor_context(context, url_args, **kwargs)
     _set_student_context(context, url_args, **kwargs)
     # check if both the user and the viewer are related to the course


### PR DESCRIPTION
This fixes an issue where if the user's context does not have a key for a course, trying to access the value for `course` results in a `KeyError`, and `500` error codes from the web server

This is the result of a refactor done in c57dc021310c1e6829483e4118fd4eca9cc2ecaa, and can be fixed with a `None`-check to make sure the key exists in the user's context, and shouldn't change functionality as there is a check to see if this variable is `None` later on in the function